### PR TITLE
Read conntrack directly from /proc to work around missing sysctl 

### DIFF
--- a/conntrack.py
+++ b/conntrack.py
@@ -23,24 +23,15 @@ class Conntrack(AgentCheck):
                                      limit=int(snapshot_limit))
 
     def _get_sysctl_metrics(self):
-        sysctl = sp.Popen(['sysctl', 'net.netfilter.nf_conntrack_max',
-                           'net.netfilter.nf_conntrack_count'],
+        max = sp.Popen(['cat', '/proc/sys/net/netfilter/nf_conntrack_max'],
                           stdout=sp.PIPE, close_fds=True).communicate()[0]
-        #
-        # net.netfilter.nf_conntrack_max = 1000000
-        # net.netfilter.nf_conntrack_count = 56
-        #
-        lines = sysctl.split('\n')
-        regexp = re.compile(r'^net\.netfilter\.nf_(\w+)\s+=\s+([0-9]+)')
-        conntrack_info = {}
-        for line in lines:
-            try:
-                match = re.search(regexp, line)
-                if match is not None:
-                    conntrack_info[match.group(1)] = match.group(2)
-            except Exception:
-                self.log.exception("Cannot parse %s" % (line,))
 
+        count = sp.Popen(['cat', '/proc/sys/net/netfilter/nf_conntrack_count'],
+                          stdout=sp.PIPE, close_fds=True).communicate()[0]
+        conntrack_info = {
+          "conntrack_max" : max,
+          "conntrack_count" : count
+        }
         return conntrack_info
 
     def _save_conntrack(self, value, limit):


### PR DESCRIPTION
The new v6 docker image from Datadog does not include the `procps` package.  As a result the system call to `sysctl` fails with a file not found error.  This PR uses `cat` to read those values directly.